### PR TITLE
Parsing invalid property names fails

### DIFF
--- a/src/core/css-syntax.js
+++ b/src/core/css-syntax.js
@@ -1026,7 +1026,7 @@ function consumeAListOfDeclarations(s) {
 			if(decl = consumeADeclaration(new TokenStream(temp))) decls.push(decl);
 		} else {
 			parseerror(s);
-			reconsume();
+			s.reconsume();
 			while(!(s.next() instanceof SemicolonToken || s.next() instanceof EOFToken))
 				consumeAComponentValue(s);
 		}


### PR DESCRIPTION
When parsing invalid css property names, for example *display, consumeAListOfDeclarations attempts calling reconsume() on the css parser instead of the TokenStream instance. Changed the code so that the call to reconsume() is called on the TokenStream instead.

However, I guess the real issue here is that invalid properties should be ignored by the parser entirely?
Feel free to reject this PR if you think I've fixed the "wrong" issue!