### PR TITLE
fix: correct failled->failed typo in Gruntfile error message

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 							
 						} catch (ex) {
 							
-							grunt.log.writeln('[ERROR] Generating doc for ' + filepath + ' failled with message: ' + ex.message);
+							grunt.log.writeln('[ERROR] Generating doc for ' + filepath + ' failed with message: ' + ex.message);
 							return '';
 							
 						}


### PR DESCRIPTION
Corrects `failled` → `failed` typo in Gruntfile.js line 127 error message. User-visible grunt error log.